### PR TITLE
Add `as_user` to Slack messaging

### DIFF
--- a/main.py
+++ b/main.py
@@ -266,7 +266,8 @@ def post_update_to_slack(event, item):
                                                   td_link,
                                                   e['startedBy'])
             }
-        ]
+        ],
+        'as_user': True
     }
 
     if 'slack_ts' in item:


### PR DESCRIPTION
This causes messages to be produced with any customised appearance that has been set for the Bot.